### PR TITLE
Fixes node.os version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-util": "^3.0.7",
     "killprocess": "0.0.2",
     "node-notifier": "^4.4.0",
-    "node.os": "^1.1.1",
+    "node.os": "1.1.1",
     "string-template": "^1.0.0",
     "vinyl-named": "^1.1.0"
   },


### PR DESCRIPTION
An unresolved issue with let bindings for the latest node.os version, caused `angel build` to fail. Setting node.os version to be _exactly_ 1.1.1 :rocket: 
