### PR TITLE
Fixes the maxBuffer limit.

### DIFF
--- a/lib/sequencial-exec.js
+++ b/lib/sequencial-exec.js
@@ -7,7 +7,7 @@ module.exports = function (entries, done) {
     }
   })
   var exec = require('child_process').exec
-  var child = exec(entries.join(' && '))
+  var child = exec(entries.join(' && '), { maxBuffer: 2000 * 1024 })
   process.stdin.resume()
   process.stdin.pipe(child.stdin)
   child.stdout.pipe(process.stdout)


### PR DESCRIPTION
@outbounder, in a recent project I've used `sequential-exec` to deploy an app that executed `ng build` as part of its deployment pipeline. It turned out that `ng build`'s output exceeded the [default `maxBuffer` limit of 200KB](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback). As a simple solution, I've put the default to 2000MB just to be safe.