### PR TITLE
Add examples and descriptions in most of the angelscripts

### DIFF
--- a/core/scripts/develop.js
+++ b/core/scripts/develop.js
@@ -4,16 +4,22 @@ module.exports = function (angel) {
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
       'node ./node_modules/.bin/angel watch',
-      'node ./index.js'
+      'node ./node_modules/.bin/nodemon ./index.js'
     ])
   })
+  .example('angel develop')
+  .description('1. runs "angel watch" which builds and watches the client impl. for changes\n' +
+               '2. starts the server')
 
   angel.on('develop :part', function (angel, next) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
       'node ./node_modules/.bin/angel watch "' + angel.cmdData.part + '"',
-      'node ./index.js'
+      'node ./node_modules/.bin/nodemon ./index.js'
     ])
   })
+  .example('angel develop :part')
+  .description('1. runs "angel watch :part" which builds and watches for changes the ":part" client impl.\n' +
+               '2. starts the server')
 }

--- a/core/scripts/develop.js
+++ b/core/scripts/develop.js
@@ -3,7 +3,7 @@ module.exports = function (angel) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
-      'node watch',
+      'node ./node_modules/.bin/angel watch',
       'node ./index.js'
     ])
   })
@@ -15,7 +15,7 @@ module.exports = function (angel) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
-      'node watch "' + angel.cmdData.part + '"',
+      'node ./node_modules/.bin/angel watch "' + angel.cmdData.part + '"',
       'node ./index.js'
     ])
   })

--- a/core/scripts/develop.js
+++ b/core/scripts/develop.js
@@ -3,8 +3,8 @@ module.exports = function (angel) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
-      'node ./node_modules/.bin/angel watch',
-      'node ./node_modules/.bin/nodemon ./index.js'
+      'node watch',
+      'node ./index.js'
     ])
   })
   .example('angel develop')
@@ -15,8 +15,8 @@ module.exports = function (angel) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
     parallel([
-      'node ./node_modules/.bin/angel watch "' + angel.cmdData.part + '"',
-      'node ./node_modules/.bin/nodemon ./index.js'
+      'node watch "' + angel.cmdData.part + '"',
+      'node ./index.js'
     ])
   })
   .example('angel develop :part')

--- a/upgrades/client/core/scripts/build.js
+++ b/upgrades/client/core/scripts/build.js
@@ -31,4 +31,9 @@ module.exports = function (angel) {
       })
     })
   })
+  .example('angel build')
+  .description('runs the client\'s build pipelines:\n' +
+               '\t JavaScript (angel buildjs)\n' +
+               '\t CSS (angel buildcss)\n' +
+               '\t Assets (angel buildassets)')
 }

--- a/upgrades/client/core/scripts/watch.js
+++ b/upgrades/client/core/scripts/watch.js
@@ -31,6 +31,11 @@ module.exports = function (angel) {
       })
     })
   })
+  .example('angel build')
+  .description('runs the client\'s watch pipelines:\n' +
+               '\t JavaScript (angel watchjs)\n' +
+               '\t CSS (angel watchcss)\n' +
+               '\t Assets (angel watchassets)')
 
   angel.on('watch :part', function (angel, next) {
     var parallel = require('organic-stem-devtools/lib/parallel-exec')
@@ -42,4 +47,9 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/angel watchassets'
     ], next)
   })
+  .example('angel watch ')
+  .description('runs the client\'s watch pipelines, watching only the ":part" part javascript:\n' +
+               '\t Partial JavaScript (angel watchjs :part)\n' +
+               '\t CSS (angel watchcss)\n' +
+               '\t Assets (angel watchassets)')
 }

--- a/upgrades/deploy/client/scripts/rollback.js
+++ b/upgrades/deploy/client/scripts/rollback.js
@@ -27,4 +27,7 @@ module.exports = function (angel) {
       ], next)
     })
   })
+  .example('angel rollback')
+  .description('1. locally checkouts to the PREVIOUS minor version - X.Y.(Z-1).\n' +
+               '2. Updates the symlink to the lastest client build ("/public/release" by default).')
 }

--- a/upgrades/deploy/core/scripts/deploy.js
+++ b/upgrades/deploy/core/scripts/deploy.js
@@ -12,6 +12,8 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/angel cell upgrade ./dna/_production/cell.json'
     ])
   })
+  .example('angel deploy production')
+  .description('deploys to the production enviornment (defined by "dna/_production/cell.json") without bumping the semver')
 
   angel.on('deploy staging', function (angel) {
     var sequence = require('organic-stem-devtools/lib/sequencial-exec')
@@ -30,6 +32,8 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/angel cell upgrade ./dna/_staging/cell.json'
     ])
   })
+  .example('angel deploy staging')
+  .description('deploys to the production enviornment (defined by "dna/_staging/cell.json") while BUMPING the MINOR semver (npm version patch)')
 
   angel.on('deploy:setup', function (angel) {
     var sequence = require('organic-stem-devtools/lib/sequencial-exec')
@@ -42,4 +46,6 @@ module.exports = function (angel) {
       'git checkout develop'
     ])
   })
+  .example('angel deploy setup')
+  .description('locally checkouts the "develop" and "staging" branches from "master" and pushes them to the remote')
 }

--- a/upgrades/deploy/core/scripts/rollback.js
+++ b/upgrades/deploy/core/scripts/rollback.js
@@ -12,4 +12,6 @@ module.exports = function (angel) {
       'git checkout v' + olderVersion // checkout taggged version
     ], next)
   })
+  .example('angel rollback')
+  .description('Locally checkouts to the PREVIOUS minor version - X.Y.(Z-1).')
 }

--- a/upgrades/server/nodemon/scripts/develop.js
+++ b/upgrades/server/nodemon/scripts/develop.js
@@ -7,6 +7,9 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/nodemon ./index.js'
     ])
   })
+  .example('angel develop')
+  .description('1. runs "angel watch" which builds and watches the client impl. for changes\n' +
+               '2. starts the server and monitors for changes')
 
   angel.on('develop :part', function (angel, next) {
     process.env.CELL_MODE = process.env.CELL_MODE || '_development'
@@ -16,4 +19,7 @@ module.exports = function (angel) {
       'node ./node_modules/.bin/nodemon ./index.js'
     ])
   })
+  .example('angel develop :part')
+  .description('1. runs "angel watch :part" which builds and watches for changes the ":part" client impl.\n' +
+               '2. starts the server and monitors for changes')
 }


### PR DESCRIPTION
# General

This PR simply adds examples and descriptions to the angelscripts in the most commonly used stack upgrades. They can be seen by invoking `angel help`.
